### PR TITLE
Remove `min_ready_sec` for compat with v4 provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+# Ignore any tfvars files used for local testing
+*.auto.tfvars

--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 1.0.0
+module_version: 1.1.0
 
 tests:
   - name: Set up in the default Network with a NAT router

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ Terraform module deploying a Spacelift worker pool on Google Cloud Platform usin
 ## Usage
 
 ```terraform
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.14.0"
+    }
+  }
+}
+
 module "my_workerpool" {
   source = "github.com/spacelift-io/terraform-google-spacelift-workerpool?ref=77f43fb641854f2a8e41611ef4aad73986688753"
 

--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,6 @@ resource "google_compute_instance_group_manager" "spacelift-worker" {
     minimal_action        = "REPLACE"
     max_surge_percent     = 20
     max_unavailable_fixed = 2
-    min_ready_sec         = 60
     replacement_method    = "SUBSTITUTE"
   }
 }


### PR DESCRIPTION
Google have removed the property and re-added it as beta. I've removed it from the `update_policy`, and I've also updated the example in the README to include a `required_providers` block to make it easier to figure this out if it happens again in future.