### PR TITLE
Adding subnet to networking

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,6 +78,7 @@ resource "google_compute_instance_template" "spacelift-worker" {
 
   network_interface {
     network = var.network
+    subnetwork = var.subnetwork
   }
 
   service_account {

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,11 @@ variable "network" {
   description = "Network to create workerpool in"
 }
 
+variable "subnetwork" {
+  type        = string
+  description = "Subnetwork to create workerpool in"
+}
+
 variable "region" {
   type        = string
   description = "Region to create workerpool in"
@@ -69,4 +74,3 @@ variable "zone" {
   type        = string
   description = "Zone to create workerpool in"
 }
-


### PR DESCRIPTION
My company follows some networking standards for CIS that require default networks not to exist in projects.   This means that default subnets do not exist so you need to name both.
1.) Let me know if you want me to put a default.
2.) Do you want an updated example to include it?