### PR TITLE
Create before Destroy to allow cleanly recycling parent

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,7 @@ resource "google_compute_instance_template" "spacelift-worker" {
   name_prefix  = "${var.instance_group_base_instance_name}-"
   machine_type = var.machine_type
   region       = var.region
+  project      = var.project
 
   disk {
     source_image = var.image
@@ -114,6 +115,7 @@ resource "google_compute_instance_group_manager" "spacelift-worker" {
 
   base_instance_name = var.instance_group_base_instance_name
   zone               = var.zone
+  project            = var.project
 
   version {
     instance_template = google_compute_instance_template.spacelift-worker.id

--- a/main.tf
+++ b/main.tf
@@ -85,6 +85,10 @@ resource "google_compute_instance_template" "spacelift-worker" {
   region       = var.region
   project      = var.project
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   disk {
     source_image = var.image
   }

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,8 @@ resource "google_compute_instance_template" "spacelift-worker" {
   }
 
   network_interface {
-    network = var.network
+    network    = var.network
+    subnetwork = var.subnetwork
   }
 
   service_account {
@@ -111,11 +112,11 @@ resource "google_compute_instance_template" "spacelift-worker" {
 }
 
 resource "google_compute_instance_group_manager" "spacelift-worker" {
-  name = var.instance_group_manager_name
+  name    = var.instance_group_manager_name
+  project = var.project
 
   base_instance_name = var.instance_group_base_instance_name
   zone               = var.zone
-  project            = var.project
 
   version {
     instance_template = google_compute_instance_template.spacelift-worker.id

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,12 @@ variable "email" {
   default     = null
 }
 
+variable "project" {
+  type        = string
+  description = "GCP project to use"
+  default     = null
+}
+
 variable "image" {
   type        = string
   description = "Disk image to use for workers"

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "email" {
 
 variable "project" {
   type        = string
-  description = "GCP project to use"
+  description = "GCP project"
   default     = null
 }
 
@@ -59,6 +59,11 @@ variable "machine_type" {
 variable "network" {
   type        = string
   description = "Network to create workerpool in"
+}
+
+variable "subnetwork" {
+  type        = string
+  description = "Subnetwork to create workerpool in"
 }
 
 variable "region" {


### PR DESCRIPTION
When altering some of the properties of the module (say, scopes), the current lifecycle behavior would get stuck because the old manager was still holding onto the template

This creates a new template, thus decoupling the deletes. Could probably also do this with a depends_on but 🤷 

(Builds on #10. Sorry about that)