### PR TITLE
Add external IP to instance template

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 1.4.0
+module_version: 1.4.1
 
 tests:
   - name: Set up in the default Network with a NAT router

--- a/main.tf
+++ b/main.tf
@@ -92,6 +92,9 @@ resource "google_compute_instance_template" "spacelift-worker" {
   network_interface {
     network    = var.network
     subnetwork = var.subnetwork
+    access_config {
+      network_tier = "PREMIUM"
+    }
   }
 
   service_account {
@@ -112,7 +115,7 @@ resource "google_compute_instance_template" "spacelift-worker" {
 }
 
 resource "google_compute_instance_group_manager" "spacelift-worker" {
-  name    = var.instance_group_manager_name
+  name = var.instance_group_manager_name
 
   base_instance_name = var.instance_group_base_instance_name
   zone               = var.zone


### PR DESCRIPTION
Previously, instances, created by the instance template, were unable to download the launcher binary, because they had no external IP addresses assigned.

This PR sets the network tier to `PREMIUM`, which assigns an ephemeral IP address to the created instances automatically.