### PR TITLE
feat: download correct binary when in FedRAMP environment

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 1.4.0
+module_version: 1.5.0
 
 tests:
   - name: Set up in the default Network with a NAT router

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terraform {
 }
 
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-google-spacelift-workerpool?ref=v1.2.0"
+  source = "github.com/spacelift-io/terraform-google-spacelift-workerpool?ref=v1.5.0"
 
   configuration = <<-EOT
     export SPACELIFT_TOKEN="${var.worker_pool_config}"


### PR DESCRIPTION
I've updated the startup script to check whether it's connecting to the MQTT broker for our FedRAMP environment. If so it downloads the FedRAMP-specific version of the launcher.