### PR TITLE
fix: use create_before_destroy for instance template

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 1.5.0
+module_version: 1.5.1
 
 tests:
   - name: Set up in the default Network with a NAT router

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terraform {
 }
 
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-google-spacelift-workerpool?ref=v1.5.0"
+  source = "github.com/spacelift-io/terraform-google-spacelift-workerpool?ref=v1.5.1"
 
   configuration = <<-EOT
     export SPACELIFT_TOKEN="${var.worker_pool_config}"

--- a/main.tf
+++ b/main.tf
@@ -124,6 +124,10 @@ resource "google_compute_instance_template" "spacelift-worker" {
     automatic_restart   = false
     on_host_maintenance = "MIGRATE"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "google_compute_instance_group_manager" "spacelift-worker" {


### PR DESCRIPTION
I realised while testing some changes that I couldn't adjust the instance template and re-apply because of the following error:

```
Error: Error waiting for Deleting Instance Template: The instance_template resource 'projects/<project-name>/global/instanceTemplates/<template-name>' is already being used by '<instance-group>'
```

I found this while testing https://github.com/spacelift-io/terraform-google-spacelift-workerpool/pull/17. I'll merge that PR first so that the version number bumps make sense.