### PR TITLE
Change FedRAMP URL to fedramp.spacelift.io

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 1.5.1
+module_version: 1.5.2
 
 tests:
   - name: Set up in the default Network with a NAT router

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terraform {
 }
 
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-google-spacelift-workerpool?ref=v1.5.1"
+  source = "github.com/spacelift-io/terraform-google-spacelift-workerpool?ref=v1.5.2"
 
   configuration = <<-EOT
     export SPACELIFT_TOKEN="${var.worker_pool_config}"

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ if [[ -n "$SPACELIFT_TOKEN" ]]; then
   decoded_token=$(echo "$SPACELIFT_TOKEN" | base64 -d 2>/dev/null || echo "")
   if [[ -n "$decoded_token" ]]; then
     broker_endpoint=$(echo "$decoded_token" | jq -r '.broker.endpoint' 2>/dev/null || echo "")
-    if [[ "$broker_endpoint" == *".gov.spacelift.io" ]]; then
+    if [[ "$broker_endpoint" == *".fedramp.spacelift.io" ]]; then
       fedrampSuffix="-fedramp"
     fi
   fi


### PR DESCRIPTION
As we think that will be more future poof.
Our environment runs in non-gov cloud and only FedRAMP moderate. In case we launch a FedRAMP High in the future, that runs in gov-cloud, the current URL could lead to a lot of customer confusion.

CU-869a9w96v