### PR TITLE
fix: graceful shutdown when instance group manager stop/terminates an instance - Self-hosted

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 1.5.2
+module_version: 1.6.0
 
 tests:
   - name: Set up in the default Network with a NAT router

--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 1.6.0
+module_version: 2.0.0
 
 tests:
   - name: Set up in the default Network with a NAT router

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ locals {
   user_data_head = <<EOF
 #!/bin/bash
 
-spacelift () {(
+spacelift() {
 set -e
   EOF
 
@@ -83,14 +83,41 @@ export SPACELIFT_METADATA_gcp_machine_type=$(curl "http://metadata.google.intern
 
 export SPACELIFT_METADATA_cloud_provider=gcp
 
-echo "Starting the Spacelift binary" >> /var/log/spacelift/info.log
-/usr/bin/spacelift-launcher 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log
-)}
+# Write environment file for the systemd service.
+# Dump the full environment so the launcher inherits everything exported above,
+# including vars set via var.configuration (e.g. SPACELIFT_TOKEN, HTTP_PROXY).
+mkdir -p /etc/spacelift
+env > /etc/spacelift/env
+chmod 600 /etc/spacelift/env
 
-spacelift
-echo "Powering off in 15 seconds" >> /var/log/spacelift/error.log
-sleep 15
-poweroff
+cat > /etc/systemd/system/spacelift-launcher.service <<UNIT
+[Unit]
+Description=Spacelift Launcher
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/spacelift/env
+ExecStart=/usr/bin/spacelift-launcher
+ExecStopPost=+/bin/sh -c 'sleep 15 && poweroff'
+KillMode=control-group
+TimeoutStopSec=30
+StandardOutput=append:/var/log/spacelift/info.log
+StandardError=append:/var/log/spacelift/error.log
+Restart=no
+UNIT
+
+systemctl daemon-reload
+systemctl start spacelift-launcher
+echo "Spacelift launcher started as systemd service" >> /var/log/spacelift/info.log
+}
+
+if ! spacelift; then
+  echo "Setup failed, powering off in 15 seconds" >> /var/log/spacelift/error.log
+  sleep 15
+  poweroff
+fi
   EOF
 }
 


### PR DESCRIPTION

   The autoscaler terminates instances via the GCP Instance Group Manager
   API. During these terminations, the launcher never received SIGTERM.
   This caused no problems, as the workers were already drained. However,
   the workers still crashed and MQTT last will was fired.

   GCP instance termination sends an ACPI power button press. Systemd
   begins graceful shutdown, but the startup script is not part of that.
   The script never gets a SIGTERM as part of the shutdown. So the machine
   just hangs until it gets forcefully terminated.

   Run the launcher as a systemd service instead. The startup script
   handles setup (download, verify, metadata), writes an environment file,
   starts the service, and exits. Cloud-init completes normally.

   ExecStopPost preserves the poweroff safety net: the instance shuts down
   after the launcher exits, whether cleanly or due to error